### PR TITLE
add unison-diy

### DIFF
--- a/unison-diy/docker-compose-Darwin.yml
+++ b/unison-diy/docker-compose-Darwin.yml
@@ -1,0 +1,21 @@
+version: '2'
+
+volumes:
+  # this volume persists Unison state even after `docker-compose down`
+  unison:
+  # this volume will be synchronized with the local directory
+  test:
+
+services:
+  sync:
+    # Unison container is built locally based on 'unison/Dockerfile'
+    build:
+      context: unison
+    volumes:
+      # local directory to synchronize
+      - ${PWD}:/root/macos
+      # Docker volume to synchronize
+      - test:/root/docker
+      # Unison state
+      - unison:/root/.unison
+

--- a/unison-diy/docker-compose-Linux.yml
+++ b/unison-diy/docker-compose-Linux.yml
@@ -1,0 +1,10 @@
+version: '2'
+
+# On Linux test volume is a simple bind mount
+volumes:
+  test:
+    driver_opts:
+      type: none
+      device: ${PWD}
+      o: bind
+

--- a/unison-diy/docker-compose.yml
+++ b/unison-diy/docker-compose.yml
@@ -1,0 +1,16 @@
+version: '2'
+services:
+  test:
+    image: busybox
+    # sleep is here to give unison time to finish the initial synchronization
+    # saner way is to trace unison logs for
+    # "Synchronization finished" or "Nothing to do"
+    command: sh -c 'sleep 10 && ls -l /root/test'
+    # volume to be mounted inside the test container
+    # - on Linux it is a plain bind mount (see docker-compose-Linux.yml)
+    # - on macOS it is a Docker volume synchronized within a dedicated 'unison'
+    # container with a quasi-bind-mounted ('osxfs') local directory by Unison
+    # (see docker-compose-Darwin.yml)
+    volumes:
+    - test:/root/test
+

--- a/unison-diy/unison/Dockerfile
+++ b/unison-diy/unison/Dockerfile
@@ -1,0 +1,23 @@
+FROM alpine:latest
+
+# Layer: latest Alpine with unison installed
+RUN apk update \
+    && apk upgrade \
+    && apk add unison
+
+# Layer: system tuning
+# increase the max number of inotify watches for large directories
+RUN echo 'fs.inotify.max_user_watches=524288' >> /etc/sysctl.conf
+
+# Layer: directories to be synchronized + Unison state
+RUN mkdir -p /root/macos /root/docker /root/.unison
+
+ENV UNISONLOCALHOSTNAME unison
+CMD unison /root/macos /root/docker \
+    -auto \
+    -batch \
+    -ignore 'Path .git' \
+    -logfile /proc/self/fd/2 \
+    -numericids \
+    -prefer /root/macos \
+    -repeat watch


### PR DESCRIPTION
This directory provides an example of building a 'do-it-yourself'
synchronization container for macOS (aka Darwin). Linux compatibility is
also provided.