### PR TITLE
Update monit template to reflect the new default

### DIFF
--- a/default_monit/docker-sync.yml
+++ b/default_monit/docker-sync.yml
@@ -8,7 +8,7 @@ syncs:
     # sync_strategy: 'native_osx' # not needed, this is the default now
     sync_excludes: ['ignored_folder', '.ignored_dot_folder']
 
-    # monit_enabled: true # not needed, this is the default
+    monit_enabled: true
 
     # increase tolerance of high cpu if regular syncing uses a lot cpu
     monit_interval: 10


### PR DESCRIPTION
This default was changed in EugenMayer/docker-sync@22d0456721c90a4ce744d13712fce0d043b197de