### PR TITLE
Fix max_attempt in unison example

### DIFF
--- a/unison/docker-sync.yml
+++ b/unison/docker-sync.yml
@@ -2,7 +2,7 @@ version: "2"
 
 options:
   verbose: true
-  max-attempt: 30
+  max_attempt: 30
 syncs:
   #IMPORTANT: ensure this name is unique and does not match your other application container name
   appcode-unison-sync: # tip: add -sync and you keep consistent names as a convention


### PR DESCRIPTION
According to the documentation[1] the option is "max_attempt", not "max-attempt".

[1] https://docker-sync.readthedocs.io/en/latest/getting-started/configuration.html#references